### PR TITLE
Improve protectedVBProject warning message

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -30,7 +30,7 @@
   "export.warn.nonMacroFileSkipped": "【WARN】⚠️Powershell: Skipped non-macro-enabled (*.xlsm) or binary (*.xlsb) workbook: {0}",
   "export.info.autoSaveCanceled": "【INFO】✅Powershell: Temporarily disabled AutoSave for {0}.",
   "export.error.autoSaveCancelFailed": "【ERROR】❌Powershell: Failed to disable AutoSave for {0}.",
-  "export.warn.protectedVBProject": "【WARN】⚠️Powershell: VBProject in {0} is protected. Please unprotect it before exporting.",
+  "export.warn.protectedVBProject": "【WARN】⚠️Powershell: VBProject in {0} is protected. To export: (1) enable 'Trust access to the VBA project object model' in Excel (File → Options → Trust Center → Trust Center Settings → Macro Settings); (2) open the VBA Editor (Alt+F11) → Tools → VBAProject Properties → Protection, remove the lock/password and save the workbook.",
   "export.warn.noModulesProcessed": "【WARN】⚠️Powershell: No modules were processed for export.",
   "export.info.exportSuccess": "【INFO】✅Powershell: Export succeeded: {0}",
   "export.warn.exportEmptyModule": "【WARN】⚠️Powershell: {0} has no code; skipped.",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -30,7 +30,7 @@
   "export.warn.nonMacroFileSkipped": "【WARN】⚠️Powershell: マクロ有効ブック(*.xlsm)/バイナリブック(*.xlsb) ではないためスキップします: {0}",
   "export.info.autoSaveCanceled": "【INFO】✅Powershell: {0} の自動保存を一時的に無効化しました。",
   "export.error.autoSaveCancelFailed": "【ERROR】❌Powershell: {0} の自動保存の無効化に失敗しました。",
-  "export.warn.protectedVBProject": "【WARN】⚠️Powershell: {0} の VBProject は保護されています。保護解除後にエクスポートして下さい。",
+  "export.warn.protectedVBProject": "【WARN】⚠️Powershell: {0} の VBProject は保護されています。エクスポートするには次の操作を行ってください: (1) Excel の [ファイル] → [オプション] → [セキュリティ センター] → [セキュリティ センターの設定] → [マクロの設定] で「VBA プロジェクト オブジェクト モデルへの信頼アクセス」を有効にする、(2) 対象ブックを開き Alt+F11 で VBA エディターを開き、[ツール] → [VBAProject のプロパティ] → [保護] タブでロック/パスワードを解除して保存してください。",
   "export.warn.noModulesProcessed": "【WARN】⚠️Powershell: エクスポート可能なモジュールがありません。",
   "export.info.exportSuccess": "【INFO】✅Powershell: エクスポート成功: {0}",
   "export.warn.exportEmptyModule": "【WARN】⚠️Powershell: {0} はコードが空のため出力しませんでした。",


### PR DESCRIPTION
Add instructions to solve the issue if the import script fails to open the workbook. This improves the onboarding experience for users who don't have enabled programmatic access to Excel VBA yet.